### PR TITLE
Partially fix Anthropic streaming logic

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -17,7 +17,6 @@ import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.emitAppend
 import ai.koog.prompt.streaming.emitEnd
-import ai.koog.prompt.streaming.emitToolCall
 import ai.koog.prompt.streaming.streamFrameFlow
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
@@ -153,12 +152,12 @@ public open class AnthropicLLMClient(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> = streamFrameFlow {
-        logger.debug { "Executing streaming prompt: $prompt with model: $model without tools" }
+        logger.debug { "Executing streaming prompt: $prompt with model: $model with tools: ${tools.map { it.name }}" }
         require(model.capabilities.contains(LLMCapability.Completion)) {
             "Model ${model.id} does not support chat completions"
         }
 
-        val request = createAnthropicRequest(prompt, emptyList(), model, true)
+        val request = createAnthropicRequest(prompt, tools, model, true)
 
         try {
             httpClient.sse(
@@ -174,29 +173,52 @@ public open class AnthropicLLMClient(
                 }
             ) {
                 incoming.collect { event ->
-                    event
-                        .takeIf { it.event == "content_block_delta" }
-                        ?.data?.trim()?.let { json.decodeFromString<AnthropicStreamResponse>(it) }
-                        ?.let { response ->
-
-                            response.delta?.text?.let { emitAppend(it) }
-                            response.delta?.toolUse?.let {
-                                emitToolCall(
-                                    id = it.id,
-                                    name = it.name,
-                                    content = it.input.toString()
-                                )
+                    when (event.event) {
+                        "content_block_start" -> {
+                            val response =
+                                event.data?.trim()?.let { json.decodeFromString<AnthropicStreamResponse>(it) }
+                            response?.contentBlock?.let { contentBlock ->
+                                // TODO Initialize tool call when content block starts
                             }
-                            val meta = response.message?.usage?.let {
-                                ResponseMetaInfo.create(
-                                    clock = clock,
-                                    totalTokensCount = it.inputTokens + it.outputTokens,
-                                    inputTokensCount = it.inputTokens,
-                                    outputTokensCount = it.outputTokens,
-                                )
-                            }
-                            response.message?.stopReason?.let { emitEnd(it, meta) }
                         }
+
+                        "content_block_delta" -> {
+                            val response =
+                                event.data?.trim()?.let { json.decodeFromString<AnthropicStreamResponse>(it) }
+
+                            response?.delta?.let { delta ->
+                                delta.text?.let { emitAppend(it) }
+                                delta.partialJson?.let {
+                                    // TODO handle partial json aggregation
+                                }
+                            }
+                        }
+
+                        "message_delta" -> {
+                            val response =
+                                event.data?.trim()?.let { json.decodeFromString<AnthropicStreamResponse>(it) }
+                            response?.delta?.stopReason?.let { finishReason ->
+                                val metaInfo = response.usage?.let { usage ->
+                                    ResponseMetaInfo.create(
+                                        clock = clock,
+                                        totalTokensCount = usage.inputTokens?.plus(usage.outputTokens ?: 0)
+                                            ?: usage.outputTokens,
+                                        inputTokensCount = usage.inputTokens,
+                                        outputTokensCount = usage.outputTokens,
+                                    )
+                                }
+                                emitEnd(finishReason, metaInfo)
+                            }
+                        }
+
+                        "error" -> {
+                            val response =
+                                event.data?.trim()?.let { json.decodeFromString<AnthropicStreamResponse>(it) }
+                            response?.error?.let {
+                                error("Anthropic streaming error: $it")
+                            }
+                        }
+                    }
                 }
             }
         } catch (e: SSEClientException) {
@@ -371,7 +393,7 @@ public open class AnthropicLLMClient(
         // Extract token count from the response
         val inputTokensCount = response.usage?.inputTokens
         val outputTokensCount = response.usage?.outputTokens
-        val totalTokensCount = response.usage?.let { it.inputTokens + it.outputTokens }
+        val totalTokensCount = response.usage?.let { it.inputTokens?.plus(it.outputTokens ?: 0) ?: it.outputTokens }
 
         val responses = response.content.map { content ->
             when (content) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/DataModel.kt
@@ -351,16 +351,16 @@ public sealed class AnthropicResponseContent {
 /**
  * Represents the usage statistics of the Anthropic LLM API.
  *
- * @property inputTokens The number of tokens sent as input to the LLM.
- * @property outputTokens The number of tokens received as output from the LLM.
+ * @property inputTokens The number of tokens sent as input to the LLM. Optional in streaming responses.
+ * @property outputTokens The number of tokens received as output from the LLM. Optional in streaming responses.
  *
  * Note: This API is marked with [InternalLLMClientApi] and is intended for internal use only.
  */
 @InternalLLMClientApi
 @Serializable
 public data class AnthropicUsage(
-    val inputTokens: Int,
-    val outputTokens: Int
+    val inputTokens: Int? = null,
+    val outputTokens: Int? = null,
 )
 
 /**
@@ -369,16 +369,24 @@ public data class AnthropicUsage(
  * This data class encapsulates the structure of a streamed response,
  * including its type, any delta updates to the content, and the complete message data when applicable.
  *
- * @property type The type of the response.
+ * @property type The type of the response (e.g., "content_block_start", "content_block_delta", "message_delta").
+ * @property index The index of the content block in streaming responses. Present in content block events.
+ * @property contentBlock The content block data for "content_block_start" events, containing tool use information.
  * @property delta An optional incremental update to the message content, represented as [AnthropicStreamDelta].
  * @property message An optional complete response message, represented as [AnthropicResponse].
+ * @property usage Optional usage statistics for the response, including token counts.
+ * @property error Optional error information if an error occurred during streaming.
  */
 @InternalLLMClientApi
 @Serializable
 public data class AnthropicStreamResponse(
     val type: String,
+    val index: Int? = null,
+    val contentBlock: AnthropicContent? = null,
     val delta: AnthropicStreamDelta? = null,
-    val message: AnthropicResponse? = null
+    val message: AnthropicResponse? = null,
+    val usage: AnthropicUsage? = null,
+    val error: AnthropicStreamError? = null
 )
 
 /**
@@ -389,14 +397,33 @@ public data class AnthropicStreamResponse(
  *
  * @property type The type of the update provided by Anthropic.
  * @property text Optional text content associated with the delta update.
- * @property toolUse Optional data about tool usage associated with the delta update, if applicable.
+ * @property partialJson Optional partial JSON content for tool use streaming.
+ * @property stopReason Optional reason why the generation process was stopped, if applicable.
  */
 @InternalLLMClientApi
 @Serializable
 public data class AnthropicStreamDelta(
     val type: String,
     val text: String? = null,
-    val toolUse: AnthropicResponseContent.ToolUse? = null
+    val partialJson: String? = null,
+    val stopReason: String? = null
+)
+
+/**
+ * Represents an error that occurred during Anthropic streaming response processing.
+ *
+ * This data class encapsulates error information received from the Anthropic API
+ * during streaming operations, providing details about the type and nature of the error.
+ *
+ * @property type The type or category of the error that occurred.
+ * @property message An optional descriptive message providing additional details about the error.
+ * Defaults to null if no message is provided.
+ */
+@InternalLLMClientApi
+@Serializable
+public data class AnthropicStreamError(
+    val type: String,
+    val message: String? = null,
 )
 
 /**


### PR DESCRIPTION
Currently, we assume that all data comes with the "content_block_delta" event, but this is incorrect. According to
https://docs.anthropic.com/en/docs/build-with-claude/streaming docs, we also need to handle: "content_block_start", "message_delta", and "error" events (if not more).

Also, our data models were slightly outdated, for example `AnthropicUsage` fields should be nullable.

I don't have much time currently to finish this, so I left TODO comments.